### PR TITLE
Reduce extension size

### DIFF
--- a/artifactory-tasks-utils/package.json
+++ b/artifactory-tasks-utils/package.json
@@ -9,8 +9,7 @@
         "azure-pipelines-task-lib": "^2.7.1",
         "azure-pipelines-tool-lib": "^0.12.0",
         "fs-extra": "^7.0.0",
-        "typed-rest-client": "^1.7.2",
-        "js-yaml": "^3.13.1"
+        "typed-rest-client": "^1.7.2"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/tasks/ArtifactoryCollectIssues/package.json
+++ b/tasks/ArtifactoryCollectIssues/package.json
@@ -9,8 +9,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
-        "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz",
-        "fs-extra": "^7.0.0"
+        "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryConan/package.json
+++ b/tasks/ArtifactoryConan/package.json
@@ -11,8 +11,6 @@
     "dependencies": {
         "asyncawait": "^1.0.7",
         "uuid": "^3.3.2",
-        "fs-extra": "^7.0.0",
-        "azure-pipelines-task-lib": "^2.7.1",
         "request-promise-lite": "^0.13.1",
         "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }

--- a/tasks/ArtifactoryDocker/package.json
+++ b/tasks/ArtifactoryDocker/package.json
@@ -9,7 +9,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryGenericDownload/Ver1/package.json
+++ b/tasks/ArtifactoryGenericDownload/Ver1/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryGenericDownload/Ver2/package.json
+++ b/tasks/ArtifactoryGenericDownload/Ver2/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryGenericDownload/Ver3/package.json
+++ b/tasks/ArtifactoryGenericDownload/Ver3/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryGenericUpload/Ver1/package.json
+++ b/tasks/ArtifactoryGenericUpload/Ver1/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryGenericUpload/Ver2/package.json
+++ b/tasks/ArtifactoryGenericUpload/Ver2/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryGo/package.json
+++ b/tasks/ArtifactoryGo/package.json
@@ -9,8 +9,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "fs-extra": "^7.0.0",
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryGradle/package.json
+++ b/tasks/ArtifactoryGradle/package.json
@@ -10,8 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
-        "fs-extra": "^7.0.0",
         "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryMaven/Ver1/package.json
+++ b/tasks/ArtifactoryMaven/Ver1/package.json
@@ -10,8 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
-        "fs-extra": "^7.0.0",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz",
         "js-yaml": "^3.13.1"
     }

--- a/tasks/ArtifactoryMaven/Ver1/package.json
+++ b/tasks/ArtifactoryMaven/Ver1/package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "azure-pipelines-task-lib": "^2.7.1",
         "fs-extra": "^7.0.0",
-        "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
+        "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz",
+        "js-yaml": "^3.13.1"
     }
 }

--- a/tasks/ArtifactoryMaven/Ver2/package.json
+++ b/tasks/ArtifactoryMaven/Ver2/package.json
@@ -10,8 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
-        "fs-extra": "^7.0.0",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryNpm/Ver1/package.json
+++ b/tasks/ArtifactoryNpm/Ver1/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryNpm/Ver2/package.json
+++ b/tasks/ArtifactoryNpm/Ver2/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryNuget/Ver1/package.json
+++ b/tasks/ArtifactoryNuget/Ver1/package.json
@@ -10,10 +10,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "asyncawait": "^1.0.7",
-        "azure-pipelines-tool-lib": "^0.11.0",
-        "fs-extra": "^7.0.0",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryNuget/Ver2/package.json
+++ b/tasks/ArtifactoryNuget/Ver2/package.json
@@ -10,10 +10,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "asyncawait": "^1.0.7",
-        "azure-pipelines-tool-lib": "^0.11.0",
-        "fs-extra": "^7.0.0",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryProperties/package.json
+++ b/tasks/ArtifactoryProperties/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryPublishBuildInfo/package.json
+++ b/tasks/ArtifactoryPublishBuildInfo/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryXrayScan/package.json
+++ b/tasks/ArtifactoryXrayScan/package.json
@@ -9,7 +9,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "azure-pipelines-task-lib": "^2.7.1",
         "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,6 @@
         "rmdir-recursive": "^0.0.1",
         "sync-request": "^6.0.0",
         "azure-pipelines-task-lib": "2.8.0",
-        "fs-extra": "^7.0.0",
         "dev-null": "^0.1.1",
         "js-yaml": "^3.13.1"
     },


### PR DESCRIPTION
Reduce extension size to 19MiB by removing `js-yaml` from `artifactory-tasks-utils`.
This change may not effect the size - Remove dependencies that already appear in `artifactory-tasks-utils` from tasks.