### PR TITLE
Fix tfx-cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "Apache-2.0",
     "dependencies": {
-        "tfx-cli": "^0.6.1"
+        "tfx-cli": "0.6.4"
     },
     "devDependencies": {
         "prettier": "1.19.1"


### PR DESCRIPTION
TFX CLI above 0.6.4 fail to publish the extension:
```
> tfx extension publish -t ***

TFS Cross Platform Command Line Interface v0.7.11
Copyright Microsoft Corporation
Checking if this extension is already published
It is, update the extension
error: Extension package is malformed/corrupted
```

This fix downgrades the tfx-cli version to 0.6.4.