### PR TITLE
Tests - Fix old repositories cleanup

### DIFF
--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -251,10 +251,10 @@ function cleanUpOldRepositories() {
             return;
         }
         let repoTimestamp = parseInt(regexGroups.pop(), 10);
-        // Convert unix timestamp to time
-        let timeDifference = new Date(Math.floor(getCurrentTimestamp() - repoTimestamp) * 1000);
+        // Subtract and convert seconds to hours
+        let timeDifference = (getCurrentTimestamp() - repoTimestamp) / 3600;
         // If more than 24 hours have passed, delete the repository.
-        if (timeDifference.getHours() > 24) {
+        if (timeDifference > 24) {
             deleteRepo(repoKey);
         }
     });


### PR DESCRIPTION
The following line return a new date. The new date is the time elapsed from 1.1.1970:
```javascript
let timeDifference = new Date(Math.floor(getCurrentTimestamp() - repoTimestamp) * 1000);
```
It can be, for example 2.1.1970, 1:00 AM.

The following line return the hours part in the date:
```javascript
timeDifference.getHours() 
```
In the above example, the hours part in the date is **1**, although the time elapsed is 25 hours.
It'll be always smaller than 24.