### PR TITLE
Reduce extension size

### DIFF
--- a/tasks/ArtifactoryConan/package.json
+++ b/tasks/ArtifactoryConan/package.json
@@ -11,7 +11,6 @@
     "dependencies": {
         "asyncawait": "^1.0.7",
         "uuid": "^3.3.2",
-        "request-promise-lite": "^0.13.1",
         "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryNuget/Ver1/package.json
+++ b/tasks/ArtifactoryNuget/Ver1/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "asyncawait": "^1.0.7",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }

--- a/tasks/ArtifactoryNuget/Ver2/nugetBuild.js
+++ b/tasks/ArtifactoryNuget/Ver2/nugetBuild.js
@@ -105,7 +105,7 @@ function runNuGet(nugetCommandCli, buildDir, cliPath, configuredServerId) {
     } catch (ex) {
         tl.setResult(tl.TaskResult.Failed, ex);
     } finally {
-        if (!!configuredServerId) {
+        if (configuredServerId) {
             utils.deleteCliServers(cliPath, buildDir, configuredServerId);
         }
     }

--- a/tasks/ArtifactoryNuget/Ver2/package.json
+++ b/tasks/ArtifactoryNuget/Ver2/package.json
@@ -10,7 +10,6 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "asyncawait": "^1.0.7",
         "artifactory-tasks-utils": "file:../../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }


### PR DESCRIPTION
* Remove unused `request-promise-lite` from Conan task
* Remove `asyncawait` from NuGet tasks.
* Fix a minor bug in NuGet push - 
  * In NuGet restore we run config before running `nuget restore`
  * In push we don't run config, but there is a cleanup of CLI servers (deleteCliServers). We should run it only after `nuget restore`. Running `deleteCliServers` with undefined CLI server list resulting in this error:
![image](https://user-images.githubusercontent.com/11367982/81912507-52ed1d80-95d7-11ea-8a19-9f6a9f3a5023.png)
