### PR TITLE
Improve npm install and CI tests times

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,10 +32,8 @@ node {
             stage('Create extension') {
                 sh '''#!/bin/bash
                     set -euxo pipefail
-                    npm i --prefix=buildScripts
-                    node buildScripts/build.js
-                    npm install -g tfx-cli@0.6.4
-                    tfx extension create
+                    npm i
+                    npm run create
                 '''
             }
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To build and run the extension sources, please follow these steps:
 1. Clone the code from git.
 2. To Build and create the JFrog Artifactory extension vsix file, run the following command.
     ```
+    npm i
     npm run create
     ```
 After the build process is completed, you'll find the vsix file in the project directory.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,6 @@ environment:
 
 install:
 - npm i -gq jfrog-cli-go
-- npm i -gq tfx-cli
 - sh: sudo pip install conan -q
 - cmd: pip install conan -q
 - cmd: nuget update -self
@@ -34,5 +33,5 @@ services:
 test_script:
 - node --version
 - npm --version
-- npm run create # Make sure that that the extension can be created
 - npm t
+- npm run create # Make sure that that the extension can be created

--- a/artifactory-tasks-utils/package.json
+++ b/artifactory-tasks-utils/package.json
@@ -2,6 +2,7 @@
     "name": "artifactory-tasks-utils",
     "version": "1.0.0",
     "author": "JFrog",
+    "private": true,
     "license": "Apache-2.0",
     "description": "Utilities for the JFrog Artifactory extension",
     "main": "utils.js",

--- a/buildScripts/build.js
+++ b/buildScripts/build.js
@@ -29,10 +29,12 @@ function installTasks() {
             let taskDir = path.join(TASKS_DIR, taskName);
             // If a package.json is missing, npm will exec the install command on the parent folder. This will cause an endless install loop.
             if (fs.existsSync(path.join(taskDir, 'package.json'))) {
+                // tasks/<task-name>/package.json
                 clean(taskDir);
                 copyTaskUtilsModules(taskDir);
                 execNpm('i', taskDir);
             } else {
+                // tasks/<task-name>/<task-version>/package.json
                 fs.readdir(taskDir, (err, taskVersionDirs) => {
                     taskVersionDirs.forEach(versToBuild => {
                         let taskVersionDir = path.join(taskDir, versToBuild);

--- a/buildScripts/build.js
+++ b/buildScripts/build.js
@@ -1,28 +1,45 @@
 const exec = require('child_process').execSync;
 const rimraf = require('rimraf');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
+const TASKS_UTILS_DIR = 'artifactory-tasks-utils';
+const TASKS_DIR = 'tasks';
+const TESTS_DIR = 'tests';
 
-cleanExecNpm('pack', 'artifactory-tasks-utils');
+installArtifactoryTaskUtils();
 installTasks();
-cleanExecNpm('i', 'tests');
+installTests();
+
+/**
+ *
+ * Install Artifactory task utils.
+ */
+function installArtifactoryTaskUtils() {
+    clean(TASKS_UTILS_DIR, true);
+    execNpm('i', TASKS_UTILS_DIR);
+    execNpm('pack', TASKS_UTILS_DIR);
+}
 
 /**
  * Install tasks.
  */
 function installTasks() {
-    fs.readdir('tasks', (err, files) => {
+    fs.readdir(TASKS_DIR, (err, files) => {
         files.forEach(taskName => {
-            let taskDir = path.join('tasks', taskName);
+            let taskDir = path.join(TASKS_DIR, taskName);
             // If a package.json is missing, npm will exec the install command on the parent folder. This will cause an endless install loop.
             if (fs.existsSync(path.join(taskDir, 'package.json'))) {
-                cleanExecNpm('i', taskDir);
+                clean(taskDir);
+                copyTaskUtilsModules(taskDir);
+                execNpm('i', taskDir);
             } else {
                 fs.readdir(taskDir, (err, taskVersionDirs) => {
                     taskVersionDirs.forEach(versToBuild => {
                         let taskVersionDir = path.join(taskDir, versToBuild);
                         if (fs.existsSync(path.join(taskVersionDir, 'package.json'))) {
-                            cleanExecNpm('i', taskVersionDir);
+                            clean(taskVersionDir);
+                            copyTaskUtilsModules(taskVersionDir);
+                            execNpm('i', taskVersionDir);
                         }
                     });
                 });
@@ -32,21 +49,40 @@ function installTasks() {
 }
 
 /**
- * Clean npm install/pack files.
- * @param cwd - (String) - Current working directory.
+ * Install tests.
  */
-function clean(cwd) {
-    rimraf.sync(path.join(cwd, 'node_modules'));
-    rimraf.sync(path.join(cwd, 'package-lock.json'));
-    rimraf.sync(path.join(cwd, '*.tgz'));
+function installTests() {
+    clean(TESTS_DIR);
+    copyTaskUtilsModules(TESTS_DIR);
+    execNpm('i', TESTS_DIR);
 }
 
 /**
- * Clean directory and execute npm command.
+ * Copy artifactory-tasks-utils/node_modules to dest/node_modules
+ * @param dest - The destination
+ */
+function copyTaskUtilsModules(dest) {
+    fs.copySync(path.join(TASKS_UTILS_DIR, 'node_modules'), path.join(dest, 'node_modules'));
+}
+
+/**
+ * Clean npm install/pack files.
+ * @param cwd - (String) - Current working directory.
+ * @param cleanPackage (Boolean) - True to clean the 'npm pack' results.
+ */
+function clean(cwd, cleanPackage) {
+    rimraf.sync(path.join(cwd, 'node_modules'));
+    rimraf.sync(path.join(cwd, 'package-lock.json'));
+    if (cleanPackage) {
+        rimraf.sync(path.join(cwd, '*.tgz'));
+    }
+}
+
+/**
+ *
  * @param command - (String) - The command to execute, i.e. install, pack, etc.
  * @param cwd - (String) - Current working directory.
  */
-function cleanExecNpm(command, cwd) {
-    clean(cwd);
-    exec('npm ' + command + ' -q', { cwd: cwd, stdio: [0, 1, 2] });
+function execNpm(command, cwd) {
+    exec('npm ' + command + ' -q --no-fund', { cwd: cwd, stdio: [0, 1, 2] });
 }

--- a/buildScripts/package.json
+++ b/buildScripts/package.json
@@ -4,12 +4,13 @@
     "author": "JFrog",
     "private": true,
     "license": "Apache-2.0",
-    "dependencies": {
+    "devDependencies": {
         "edit-json-file": "^1.1.0",
         "command-line-args": "^5.0.2",
         "command-line-usage": "^5.0.5",
         "compare-versions": "^3.4.0",
         "assert": "^1.4.1",
-        "rimraf": "^2.6.2"
+        "rimraf": "^2.6.2",
+        "fs-extra": "^7.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     },
     "scripts": {
         "format": "prettier --write \"**/{*.js,package.json}\"",
-        "preinstall": "cd buildScripts && npm i",
+        "preinstall": "cd buildScripts && npm i --no-fund",
         "install": "node buildScripts/build.js",
-        "create": "npm i && tfx extension create",
-        "test": "npm i && npm t --prefix=tests",
-        "publish-private": "npm i && bash buildScripts/publish-private.sh"
+        "create": "tfx extension create",
+        "test": "npm i --no-fund && npm t --prefix=tests",
+        "publish-private": "npm i --no-fund && bash buildScripts/publish-private.sh"
     }
 }


### PR DESCRIPTION
* Reduce `npm install` time by copying the shared dependencies of artifactory-task-utils to each one of the tasks. Installation of each task will avoid downloading this dependencies.
* Clean up build log.
* Currently the CI tests run twice - once before creating the VSIX package and once before running the tests. Now we will run `npm i` automatically only before tests.

**Benchmarks**

Benchmark on my machine, running `time npm i`
* Before: `270.79s user 35.66s system 116% cpu 4:22.39 total` 
* After: `62.13s user 16.68s system 74% cpu 1:45.50 total`

Benchmark on Appveyor:
* Before: https://ci.appveyor.com/project/yahavi/artifactory-azure-devops-extension/builds/32905150
  * Windows: `17 min 35 sec`
  * Ubuntu:  `9 min 37 sec`

* After: https://ci.appveyor.com/project/yahavi/artifactory-azure-devops-extension/builds/32917562
  * Windows: `12 min 30 sec`
  * Ubuntu: ` 8 min 48 sec`