### PR TITLE
Remove fs-extra from artifactory-tasks-utils

### DIFF
--- a/artifactory-tasks-utils/package.json
+++ b/artifactory-tasks-utils/package.json
@@ -9,7 +9,6 @@
     "dependencies": {
         "azure-pipelines-task-lib": "^2.7.1",
         "azure-pipelines-tool-lib": "^0.12.0",
-        "fs-extra": "^7.0.0",
         "typed-rest-client": "^1.7.2"
     },
     "scripts": {

--- a/artifactory-tasks-utils/tools.js
+++ b/artifactory-tasks-utils/tools.js
@@ -1,5 +1,5 @@
 // Based on toolLib.downloadTool:
-const fs = require('fs-extra');
+const fs = require('fs');
 const tl = require('azure-pipelines-task-lib/task');
 const path = require('path');
 const httpm = require('typed-rest-client/HttpClient');

--- a/artifactory-tasks-utils/utils.js
+++ b/artifactory-tasks-utils/utils.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra');
+const fs = require('fs');
 const tl = require('azure-pipelines-task-lib/task');
 const path = require('path');
 const execSync = require('child_process').execSync;

--- a/tasks/ArtifactoryCollectIssues/collectIssues.js
+++ b/tasks/ArtifactoryCollectIssues/collectIssues.js
@@ -1,7 +1,7 @@
 const tl = require('azure-pipelines-task-lib/task');
 const utils = require('artifactory-tasks-utils');
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('fs');
 
 const cliCollectIssuesCommand = 'rt bag';
 

--- a/tasks/ArtifactoryConan/package.json
+++ b/tasks/ArtifactoryConan/package.json
@@ -9,7 +9,8 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "uuid": "^3.3.2",
-        "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
+        "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz",
+        "fs-extra": "^7.0.1",
+        "uuid": "^3.3.2"
     }
 }

--- a/tasks/ArtifactoryDotnet/dotnetBuild.js
+++ b/tasks/ArtifactoryDotnet/dotnetBuild.js
@@ -1,5 +1,5 @@
 const tl = require('azure-pipelines-task-lib/task');
-const fs = require('fs-extra');
+const fs = require('fs');
 const utils = require('artifactory-tasks-utils');
 const path = require('path');
 const solutionPathUtil = require('artifactory-tasks-utils/solutionPathUtil');

--- a/tasks/ArtifactoryGenericDownload/Ver1/downloadArtifacts.js
+++ b/tasks/ArtifactoryGenericDownload/Ver1/downloadArtifacts.js
@@ -1,7 +1,7 @@
 const tl = require('azure-pipelines-task-lib/task');
 const utils = require('artifactory-tasks-utils');
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('fs');
 
 const cliDownloadCommand = 'rt dl';
 

--- a/tasks/ArtifactoryGo/goBuild.js
+++ b/tasks/ArtifactoryGo/goBuild.js
@@ -1,5 +1,5 @@
 const tl = require('azure-pipelines-task-lib/task');
-const fs = require('fs-extra');
+const fs = require('fs');
 const utils = require('artifactory-tasks-utils');
 
 const cliGoCommand = 'rt go';

--- a/tasks/ArtifactoryMaven/Ver1/mavenBuild.js
+++ b/tasks/ArtifactoryMaven/Ver1/mavenBuild.js
@@ -1,7 +1,7 @@
 let tl = require('azure-pipelines-task-lib/task');
 const path = require('path');
 let utils = require('artifactory-tasks-utils');
-const fs = require('fs-extra');
+const fs = require('fs');
 const yaml = require('js-yaml');
 const buildToolsConfigVersion = 1;
 const cliMavenCommand = 'rt mvn';
@@ -141,5 +141,5 @@ function createYamlFile(configPath, buildToolType, resolverObj, deployerObj) {
     }
     let configInfo = yaml.safeDump(yamlDocument);
     console.log(configInfo);
-    fs.outputFileSync(configPath, configInfo);
+    fs.writeFileSync(configPath, configInfo);
 }

--- a/tasks/ArtifactoryNpm/Ver1/npmBuild.js
+++ b/tasks/ArtifactoryNpm/Ver1/npmBuild.js
@@ -1,5 +1,5 @@
 const tl = require('azure-pipelines-task-lib/task');
-const fs = require('fs-extra');
+const fs = require('fs');
 const utils = require('artifactory-tasks-utils');
 const npmInstallCommand = 'rt npmi';
 const npmPublishCommand = 'rt npmp';

--- a/tasks/ArtifactoryNpm/Ver2/npmBuild.js
+++ b/tasks/ArtifactoryNpm/Ver2/npmBuild.js
@@ -1,5 +1,5 @@
 const tl = require('azure-pipelines-task-lib/task');
-const fs = require('fs-extra');
+const fs = require('fs');
 const utils = require('artifactory-tasks-utils');
 
 const npmInstallCommand = 'rt npmi';

--- a/tasks/ArtifactoryNuget/Ver1/nugetBuild.js
+++ b/tasks/ArtifactoryNuget/Ver1/nugetBuild.js
@@ -1,6 +1,6 @@
 const tl = require('azure-pipelines-task-lib/task');
 const toolLib = require('azure-pipelines-tool-lib/tool');
-const fs = require('fs-extra');
+const fs = require('fs');
 const utils = require('artifactory-tasks-utils');
 const solutionPathUtil = require('artifactory-tasks-utils/solutionPathUtil');
 const NUGET_TOOL_NAME = 'NuGet';

--- a/tasks/ArtifactoryNuget/Ver2/nugetBuild.js
+++ b/tasks/ArtifactoryNuget/Ver2/nugetBuild.js
@@ -1,6 +1,6 @@
 const tl = require('azure-pipelines-task-lib/task');
 const toolLib = require('azure-pipelines-tool-lib/tool');
-const fs = require('fs-extra');
+const fs = require('fs');
 const utils = require('artifactory-tasks-utils');
 const NUGET_TOOL_NAME = 'NuGet';
 const NUGET_EXE_FILENAME = 'nuget.exe';

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,14 +8,15 @@
     "main": "testUtils.js",
     "dependencies": {
         "artifactory-tasks-utils": "file:../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz",
-        "mocha": "^5.2.0",
-        "path": "^0.12.7",
-        "http-tunneling-proxy": "^0.3.4",
-        "rmdir-recursive": "^0.0.1",
-        "sync-request": "^6.0.0",
         "azure-pipelines-task-lib": "2.8.0",
         "dev-null": "^0.1.1",
-        "js-yaml": "^3.13.1"
+        "fs-extra": "^7.0.1",
+        "http-tunneling-proxy": "^0.3.4",
+        "js-yaml": "^3.13.1",
+        "mocha": "^5.2.0",
+        "path": "^0.12.7",
+        "rmdir-recursive": "^0.0.1",
+        "sync-request": "^6.0.0"
     },
     "scripts": {
         "test": "npm i && mocha tests.js -t 600000"


### PR DESCRIPTION
* Reduce 2 MB from the extension size by removing `fs-extra` from most of the tasks.
* To reduce the risks, retain `fs-extra` in Conan tasks.

Tests results: 
https://ci.appveyor.com/project/yahavi/artifactory-azure-devops-extension/builds/33638221