### PR TITLE
Use --url "URL" instead of --url="URL"

### DIFF
--- a/artifactory-tasks-utils/utils.js
+++ b/artifactory-tasks-utils/utils.js
@@ -312,7 +312,7 @@ function addIntParam(cliCommand, inputParam, cliParam) {
 
 function addUrlAndCredentialsParams(cliCommand, artifactoryService) {
     let artifactoryUrl = tl.getEndpointUrl(artifactoryService, false);
-    cliCommand = cliJoin(cliCommand, '--url=' + quote(artifactoryUrl));
+    cliCommand = cliJoin(cliCommand, '--url', quote(artifactoryUrl));
     cliCommand = addArtifactoryCredentials(cliCommand, artifactoryService);
     return cliCommand;
 }


### PR DESCRIPTION
The equals sign breaks `jfrog rt curl` as detailed in #186.