### PR TITLE
Added `addUrlAndCredentials` variable

### DIFF
--- a/tasks/JfrogCli/jfrogCliRun.js
+++ b/tasks/JfrogCli/jfrogCliRun.js
@@ -36,7 +36,9 @@ function RunTaskCbk(cliPath) {
         // Remove 'jfrog' and space from the begining of the command string, so we can use the CLI's path
         cliCommand = cliCommand.slice(cliExecName.length + 1);
         cliCommand = utils.cliJoin(cliPath, cliCommand);
-        cliCommand = utils.addUrlAndCredentialsParams(cliCommand, artifactoryService);
+        if (tl.getBoolInput('addUrlAndCredentials')) {
+            cliCommand = utils.addUrlAndCredentialsParams(cliCommand, artifactoryService);
+        }
         // Execute the cli command.
         utils.executeCliCommand(cliCommand, workDir);
     } catch (executionException) {

--- a/tasks/JfrogCli/task.json
+++ b/tasks/JfrogCli/task.json
@@ -55,6 +55,14 @@
                 "expression": "isMatch(value, '^jfrog rt ', 'IgnoreCase')",
                 "message": "The command must start with `jfrog rt `."
             }
+        },
+        {
+            "name": "addUrlAndCredentials",
+            "type": "boolean",
+            "label": "Add --url, --user, --password arguments to the command",
+            "defaultValue": "true",
+            "required": true,
+            "helpMarkDown": "Deselect it, if provided JFrog CLI command does not support --url, --user, --password arguments."
         }
     ],
     "execution": {


### PR DESCRIPTION
added for the JFrog CLI task, which would help to control --url, --password and --user arguments attachment for provided jfrog rt command
The current problem with jfrog cli task, is that not all commands supports --url, --user and --password arguments. This switch would allow to control those 3 arguments attachment to jfrog command execution

- [x] All [tests](https://github.com/jfrog/artifactory-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
