### PR TITLE
Allow run Jenkins job as a root user

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,8 +40,10 @@ node("docker") {
             stage('Create extension') {
                 sh '''#!/bin/bash
                     set -euxo pipefail
-                    npm i
+                    npm i --unsafe-perm
                     npm run create
+                    # Verify vsix file is larger than 15M
+                    find . -iname "JFrog.jfrog-artifactory-vsts-extension*" -size +15M | grep .
                 '''
             }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
#204 #205 #206 #207

### The issue
Running `npm i` as a root user prevent npm from running our [scripts](https://github.com/jfrog/artifactory-azure-devops-extension/blob/1.10.5/package.json#L15) in the package.json. 
As mention in the npm [documentation](https://docs.npmjs.com/misc/scripts#user): 

> If npm was invoked with root privileges, then it will change the uid to the user account or uid specified by the user config, which defaults to nobody.

"nobody" has no permissions to run commands in the root directories. That’s why we get the following errors:
> npm WARN lifecycle artifactory-vsts-extension@1.0.0-preinstall: cannot run in wd artifactory-vsts-extension@1.0.0 cd buildScripts && npm i --no-fund
npm WARN lifecycle artifactory-vsts-extension@1.0.0-install: cannot run in wd artifactory-vsts-extension@1.0.0 node buildScripts/build.js

As a result `buildScripts/build.js` has not been executed. The `npm i` didn't trigger the tasks installations - no `node_modules` directories appear under `tasks/<taskName>/` directories.
 
### Solution
Instead of running `npm i`, run `npm i --unsafe-perm` to allow running the scripts as a root user.

### Prevention
Running `npm i` as a root creates a smaller than 1M VSIX file. We can check that the size of the extension created is bigger than 15M.