### PR TITLE
Add support for "jfrog rt curl" by the JFrog CLI task

### DIFF
--- a/artifactory-tasks-utils/utils.js
+++ b/artifactory-tasks-utils/utils.js
@@ -52,6 +52,7 @@ module.exports = {
     appendBuildFlagsToCliCommand: appendBuildFlagsToCliCommand,
     deprecatedTaskMessage: deprecatedTaskMessage,
     comparVersions: comparVersions,
+    useCliServer: useCliServer,
     minCustomCliVersion: minCustomCliVersion,
     defaultJfrogCliVersion: defaultJfrogCliVersion
 };
@@ -203,6 +204,16 @@ function configureCliServer(artifactory, serverId, cliPath, buildDir) {
         // Add username and password.
         cliCommand = cliJoin(cliCommand, '--user=' + quote(artifactoryUser), '--password=' + quote(artifactoryPassword));
     }
+    return executeCliCommand(cliCommand, buildDir, null);
+}
+
+/**
+ *  Use given serverId as defualt
+ * @returns {Buffer|string}
+ * @throws In CLI execution failure.
+ */
+function useCliServer(serverId, cliPath, buildDir) {
+    let cliCommand = cliJoin(cliPath, 'rt use', quote(serverId));
     return executeCliCommand(cliCommand, buildDir, null);
 }
 

--- a/tasks/JfrogCli/jfrogCliRun.js
+++ b/tasks/JfrogCli/jfrogCliRun.js
@@ -37,12 +37,18 @@ function RunTaskCbk(cliPath) {
         return;
     }
     try {
-        // Remove 'jfrog' and space from the begining of the command string, so we can use the CLI's path
+        let serverId = 'rt-server-' + utils.getCurrentTimestamp();
+        // Execute the cli config command.
+        utils.configureCliServer(artifactoryService, serverId, cliPath, workDir);
+        // Use the server we just created
+        utils.useCliServer(serverId, cliPath, workDir);
+        // Remove 'jfrog' and space from the beginning of the command string, so we can use the CLI's path
         cliCommand = cliCommand.slice(cliExecName.length + 1);
         cliCommand = utils.cliJoin(cliPath, cliCommand);
-        cliCommand = utils.addUrlAndCredentialsParams(cliCommand, artifactoryService);
         // Execute the cli command.
         utils.executeCliCommand(cliCommand, workDir);
+        // delete the server we configured
+        utils.deleteCliServers(cliPath, workDir, [serverId]);
     } catch (executionException) {
         tl.setResult(tl.TaskResult.Failed, executionException);
     }

--- a/tasks/JfrogCli/task.json
+++ b/tasks/JfrogCli/task.json
@@ -50,7 +50,7 @@
             "label": "Command to run",
             "defaultValue": "jfrog rt <COMMAND>",
             "required": true,
-            "helpMarkDown": "Set your JFrog CLI command after 'jfrog rt '. There is no need to provide the URL and credentials options.",
+            "helpMarkDown": "Set your JFrog CLI command after 'jfrog rt '. There is no need to provide the URL, the credentials or the server ID options.",
             "validation": {
                 "expression": "isMatch(value, '^jfrog rt ', 'IgnoreCase')",
                 "message": "The command must start with `jfrog rt `."


### PR DESCRIPTION
The Jfrog cli task changed to create artifactory server config (rt c)
instead of the url and credentials flags that was used before.

- [ ] All [tests](https://github.com/jfrog/artifactory-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
