### PR TITLE
AppVeyor - Upgrade Python from  python 3.8.2 to  python 3.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 build: off
-stack: node 8, python 3.8.2
+stack: node 8, python 3.9
 skip_tags: true
 environment:
   matrix:


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----
Avoiding the following AppVeyor message when running tests on Ubuntu image:

> `Error enabling 'python' stack: Python version not found: 3.8.2. Available Python versions: 3.9, 3.4, 3.7, 3.5.10, 2.7, 3.8.6, 3.6.12, 3.5, 3.8, 3.9.0, 3.7.9, 3.4.10, 3.6, 2.7.18`