### PR TITLE
Decrease package size to 14M

### DIFF
--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,8 @@
+JFrog
+
+    THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+    Do Not Translate or Localize
+
+    This project incorporates various components from those projects listed below. JFrog is using such components under the following original copyright notices and the licenses 
+
+    1.  duniul/clean-modules (https://github.com/duniul/clean-modules) - Copyright (c) 2020, Daniel Grefberg; Licensed under ISC License (https://github.com/duniul/clean-modules/blob/master/LICENSE)

--- a/buildScripts/build.js
+++ b/buildScripts/build.js
@@ -16,7 +16,7 @@ installTests();
  */
 function installArtifactoryTaskUtils() {
     clean(TASKS_UTILS_DIR, true);
-    execNpm('i', TASKS_UTILS_DIR);
+    installAndShrink(TASKS_UTILS_DIR);
     execNpm('pack', TASKS_UTILS_DIR);
 }
 
@@ -36,7 +36,7 @@ function installTasks() {
                 // tasks/<task-name>/package.json
                 clean(taskDir);
                 copyTaskUtilsModules(taskDir);
-                execNpm('i', taskDir);
+                installAndShrink(taskDir);
             } else {
                 // tasks/<task-name>/<task-version>/package.json
                 fs.readdir(taskDir, (err, taskVersionDirs) => {
@@ -45,7 +45,7 @@ function installTasks() {
                         if (fs.existsSync(path.join(taskVersionDir, 'package.json'))) {
                             clean(taskVersionDir);
                             copyTaskUtilsModules(taskVersionDir);
-                            execNpm('i', taskVersionDir);
+                            installAndShrink(taskVersionDir);
                         }
                     });
                 });
@@ -91,4 +91,13 @@ function clean(cwd, cleanPackage) {
  */
 function execNpm(command, cwd) {
     exec('npm ' + command + ' -q --no-fund', { cwd: cwd, stdio: [0, 1, 2] });
+}
+
+/**
+ * Run 'npm install' and run clean-modules on the node_modules created.
+ * @param cwd - (String) - Current working directory.
+ */
+function installAndShrink(cwd) {
+    execNpm('i', cwd);
+    exec('npx clean-modules -y --exclude "**/shelljs/src/test.js" ' + cwd, { stdio: [0, 1, 2] });
 }

--- a/buildScripts/build.js
+++ b/buildScripts/build.js
@@ -99,5 +99,5 @@ function execNpm(command, cwd) {
  */
 function installAndShrink(cwd) {
     execNpm('i', cwd);
-    exec('npx clean-modules -y --exclude "**/shelljs/src/test.js" ' + cwd, { stdio: [0, 1, 2] });
+    exec('npx clean-modules -y --exclude "**/shelljs/src/test.js" ' + path.join(cwd, 'node_modules'), { stdio: [0, 1, 2] });
 }

--- a/buildScripts/package.json
+++ b/buildScripts/package.json
@@ -5,12 +5,13 @@
     "private": true,
     "license": "Apache-2.0",
     "devDependencies": {
-        "edit-json-file": "^1.1.0",
+        "assert": "^1.4.1",
+        "clean-modules": "^1.0.4",
         "command-line-args": "^5.0.2",
         "command-line-usage": "^5.0.5",
         "compare-versions": "^3.4.0",
-        "assert": "^1.4.1",
-        "rimraf": "^2.6.2",
-        "fs-extra": "^7.0.0"
+        "edit-json-file": "^1.1.0",
+        "fs-extra": "^7.0.0",
+        "rimraf": "^2.6.2"
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Reduce package size from  22330710 (21M) to 14561491 (14M).
This achieved by running [clean-modules](https://github.com/duniul/clean-modules) on the generated node_modules.
