### PR TITLE
Fix server id deletion on Nuget restore

### DIFF
--- a/artifactory-tasks-utils/utils.js
+++ b/artifactory-tasks-utils/utils.js
@@ -663,7 +663,8 @@ function determineCliWorkDir(defaultPath, providedPath) {
 function assembleBuildToolServerId(buildToolType, buildToolCmd) {
     let buildName = tl.getVariable('Build.DefinitionName');
     let buildNumber = tl.getVariable('Build.BuildNumber');
-    return [buildName, buildNumber, buildToolType, buildToolCmd].join('_');
+    let timestamp = Math.floor(Date.now());
+    return [buildName, buildNumber, buildToolType, buildToolCmd, timestamp].join('_');
 }
 
 function createBuildToolConfigFile(cliPath, artifactoryService, cmd, requiredWorkDir, configCommand, repoResolver, repoDeploy) {

--- a/tasks/ArtifactoryDotnet/dotnetBuild.js
+++ b/tasks/ArtifactoryDotnet/dotnetBuild.js
@@ -31,10 +31,10 @@ function performDotnetRestore(cliPath) {
         } else {
             sourcePath = sourceFile;
         }
-        let configuredServerId = performDotnetConfig(cliPath, sourcePath, 'targetResolveRepo');
+        let configuredServerIdsArray = performDotnetConfig(cliPath, sourcePath, 'targetResolveRepo');
         let dotnetArguments = buildDotnetCliArgs();
         let dotnetCommand = utils.cliJoin(cliPath, cliDotnetCoreRestoreCommand, dotnetArguments);
-        executeCliCommand(dotnetCommand, sourcePath, cliPath, configuredServerId);
+        executeCliCommand(dotnetCommand, sourcePath, cliPath, configuredServerIdsArray);
     });
 }
 
@@ -53,7 +53,7 @@ function performDotnetNugetPush(cliPath) {
     executeCliCommand(uploadCommand, buildDir, cliPath);
 }
 
-function executeCliCommand(cliCmd, buildDir, cliPath, configuredServerId) {
+function executeCliCommand(cliCmd, buildDir, cliPath, configuredServerIdsArray) {
     let collectBuildInfo = tl.getBoolInput('collectBuildInfo');
     if (collectBuildInfo) {
         let buildName = tl.getInput('buildName', true);
@@ -66,8 +66,8 @@ function executeCliCommand(cliCmd, buildDir, cliPath, configuredServerId) {
     } catch (ex) {
         tl.setResult(tl.TaskResult.Failed, ex);
     } finally {
-        if (configuredServerId) {
-            utils.deleteCliServers(cliPath, buildDir, configuredServerId);
+        if (configuredServerIdsArray) {
+            utils.deleteCliServers(cliPath, buildDir, configuredServerIdsArray);
         }
     }
 }

--- a/tasks/ArtifactoryGo/goBuild.js
+++ b/tasks/ArtifactoryGo/goBuild.js
@@ -8,7 +8,7 @@ const cliGoConfigCommand = 'rt go-config';
 const newGpCommandMinVersion = '1.46.1';
 const resolutionRepoInputName = 'resolutionRepo';
 const deploymentRepoInputName = 'targetRepo';
-let configuredServerId;
+let configuredServerIdsArray;
 
 function RunTaskCbk(cliPath) {
     let defaultWorkDir = tl.getVariable('System.DefaultWorkingDirectory');
@@ -70,7 +70,7 @@ function performGoCommand(goCommand, cliPath, requiredWorkDir) {
  * @param repoDeploy - Deployment repo input name, null if not needed.
  */
 function performGoConfig(cliPath, requiredWorkDir, repoResolve, repoDeploy) {
-    configuredServerId = utils.createBuildToolConfigFile(
+    configuredServerIdsArray = utils.createBuildToolConfigFile(
         cliPath,
         'artifactoryService',
         'go',
@@ -125,7 +125,7 @@ function executeGoCliCommand(cliCommand, cliPath, requiredWorkDir) {
     } catch (ex) {
         tl.setResult(tl.TaskResult.Failed, ex);
     } finally {
-        utils.deleteCliServers(cliPath, requiredWorkDir, configuredServerId);
+        utils.deleteCliServers(cliPath, requiredWorkDir, configuredServerIdsArray);
     }
     // Ignored if the build's result was previously set to 'Failed'.
     tl.setResult(tl.TaskResult.Succeeded, 'Build Succeeded.');
@@ -135,7 +135,7 @@ function configureGoCliServer(cliPath, buildDir, serverType) {
     const serverId = utils.assembleBuildToolServerId('go', serverType);
     let artifactoryService = tl.getInput('artifactoryService', false);
     utils.configureCliServer(artifactoryService, serverId, cliPath, buildDir);
-    configuredServerId = [serverId];
+    configuredServerIdsArray = [serverId];
 }
 
 function shouldUseLegacyGpCmd() {

--- a/tasks/ArtifactoryNpm/Ver2/npmBuild.js
+++ b/tasks/ArtifactoryNpm/Ver2/npmBuild.js
@@ -6,7 +6,7 @@ const npmInstallCommand = 'rt npmi';
 const npmPublishCommand = 'rt npmp';
 const npmCiCommand = 'rt npmci';
 const npmConfigCommand = 'rt npmc';
-let configuredServerId;
+let configuredServerIdsArray;
 
 function RunTaskCbk(cliPath) {
     let defaultWorkDir = tl.getVariable('System.DefaultWorkingDirectory');
@@ -66,12 +66,12 @@ function performNpmCommand(cliNpmCommand, addThreads, cliPath, collectBuildInfo,
     } catch (ex) {
         tl.setResult(tl.TaskResult.Failed, ex);
     } finally {
-        utils.deleteCliServers(cliPath, requiredWorkDir, configuredServerId);
+        utils.deleteCliServers(cliPath, requiredWorkDir, configuredServerIdsArray);
     }
 }
 
 function performNpmConfigCommand(cliPath, requiredWorkDir, repoResolve, repoDeploy) {
-    configuredServerId = utils.createBuildToolConfigFile(
+    configuredServerIdsArray = utils.createBuildToolConfigFile(
         cliPath,
         'artifactoryService',
         'npm',

--- a/tasks/ArtifactoryNuget/Ver2/nugetBuild.js
+++ b/tasks/ArtifactoryNuget/Ver2/nugetBuild.js
@@ -76,8 +76,8 @@ function exec(cliPath, nugetCommand) {
             }
             let nugetArguments = addNugetArgsToCommands();
             nugetCommandCli = utils.cliJoin(cliPath, cliNuGetCommand, nugetCommand, nugetArguments);
-            let configuredServerId = performNugetConfig(cliPath, solutionPath, 'targetResolveRepo');
-            runNuGet(nugetCommandCli, solutionPath, cliPath, configuredServerId);
+            let resolverServerId = performNugetConfig(cliPath, solutionPath, 'targetResolveRepo');
+            runNuGet(nugetCommandCli, solutionPath, cliPath, [resolverServerId]);
         });
     } else {
         // Perform push command.
@@ -93,7 +93,7 @@ function exec(cliPath, nugetCommand) {
     }
 }
 
-function runNuGet(nugetCommandCli, buildDir, cliPath, configuredServerId) {
+function runNuGet(nugetCommandCli, buildDir, cliPath, configuredServerIdsArray) {
     let collectBuildInfo = tl.getBoolInput('collectBuildInfo');
 
     if (collectBuildInfo) {
@@ -107,8 +107,8 @@ function runNuGet(nugetCommandCli, buildDir, cliPath, configuredServerId) {
     } catch (ex) {
         tl.setResult(tl.TaskResult.Failed, ex);
     } finally {
-        if (configuredServerId) {
-            utils.deleteCliServers(cliPath, buildDir, configuredServerId);
+        if (configuredServerIdsArray) {
+            utils.deleteCliServers(cliPath, buildDir, configuredServerIdsArray);
         }
     }
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Fixes the following issue that was due to wrong input to `deleteCliServers`:
```
##[debug]Executing cliCommand: C:\hostedtoolcache\windows\jfrog\1.47.1\x64\jfrog.exe c remove "n" --quiet
[Info] "n" configuration could not be found.

##[debug]JFROG_CLI_TASK_SELECTED_VERSION_AZURE=1.47.1
##[debug]Executing cliCommand: C:\hostedtoolcache\windows\jfrog\1.47.1\x64\jfrog.exe c remove "u" --quiet
[Info] "u" configuration could not be found.

##[debug]JFROG_CLI_TASK_SELECTED_VERSION_AZURE=1.47.1
##[debug]Executing cliCommand: C:\hostedtoolcache\windows\jfrog\1.47.1\x64\jfrog.exe c remove "g" --quiet
[Info] "g" configuration could not be found.

##[debug]JFROG_CLI_TASK_SELECTED_VERSION_AZURE=1.47.1
##[debug]Executing cliCommand: C:\hostedtoolcache\windows\jfrog\1.47.1\x64\jfrog.exe c remove "e" --quiet
[Info] "e" configuration could not be found.
.....
```