### PR TITLE
Run 'clean-modules' only on artifactory-task-utils

### DIFF
--- a/buildScripts/build.js
+++ b/buildScripts/build.js
@@ -16,7 +16,8 @@ installTests();
  */
 function installArtifactoryTaskUtils() {
     clean(TASKS_UTILS_DIR, true);
-    installAndShrink(TASKS_UTILS_DIR);
+    execNpm('i', TASKS_UTILS_DIR);
+    exec('npx clean-modules -y --exclude "**/shelljs/src/test.js" ' + path.join(TASKS_UTILS_DIR, 'node_modules'), { stdio: [0, 1, 2] });
     execNpm('pack', TASKS_UTILS_DIR);
 }
 
@@ -36,7 +37,7 @@ function installTasks() {
                 // tasks/<task-name>/package.json
                 clean(taskDir);
                 copyTaskUtilsModules(taskDir);
-                installAndShrink(taskDir);
+                execNpm('i', taskDir);
             } else {
                 // tasks/<task-name>/<task-version>/package.json
                 fs.readdir(taskDir, (err, taskVersionDirs) => {
@@ -45,7 +46,7 @@ function installTasks() {
                         if (fs.existsSync(path.join(taskVersionDir, 'package.json'))) {
                             clean(taskVersionDir);
                             copyTaskUtilsModules(taskVersionDir);
-                            installAndShrink(taskVersionDir);
+                            execNpm('i', taskVersionDir);
                         }
                     });
                 });
@@ -91,13 +92,4 @@ function clean(cwd, cleanPackage) {
  */
 function execNpm(command, cwd) {
     exec('npm ' + command + ' -q --no-fund', { cwd: cwd, stdio: [0, 1, 2] });
-}
-
-/**
- * Run 'npm install' and run clean-modules on the node_modules created.
- * @param cwd - (String) - Current working directory.
- */
-function installAndShrink(cwd) {
-    execNpm('i', cwd);
-    exec('npx clean-modules -y --exclude "**/shelljs/src/test.js" ' + path.join(cwd, 'node_modules'), { stdio: [0, 1, 2] });
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

To speed up installation time, run 'clean-modules' only on artifactory-task-utils.