### PR TITLE
Update publish-private.sh

### DIFF
--- a/buildScripts/publish-private.sh
+++ b/buildScripts/publish-private.sh
@@ -6,6 +6,7 @@
 # Precondition: Set 2 environment variables:
 # 1. ADO_ARTIFACTORY_DEVELOPER - Developer ID in Visual Studio (Organization name in Azure DevOps)
 # 2. ADO_ARTIFACTORY_API_KEY - API key in Visual Studio (Personal access tokens under 'Security' menu, configured to 'All accessible organizations' in 'Organization' and 'Full access' in 'Scopes'.)
+# 3. Create publisher at https://aka.ms/vsm-create-publisher. It's Name (and ID) should be the value of '$ADO_ARTIFACTORY_DEVELOPER-private' (other details are not required).
 
 if [ -z "$ADO_ARTIFACTORY_DEVELOPER" ]; then
     echo "Please set ADO_ARTIFACTORY_DEVELOPER first"
@@ -27,8 +28,7 @@ sed -i '' "s/\"version\": \".*..*..*\"/\"version\": \"${RANDOM}.${RANDOM}.${RAND
 
 
 tfx extension unshare -t $ADO_ARTIFACTORY_API_KEY --extension-id jfrog-artifactory-vsts-extension --publisher $PUBLISHER --unshare-with $ADO_ARTIFACTORY_DEVELOPER 2>/dev/null
-tfx extension publisher delete -t $ADO_ARTIFACTORY_API_KEY --publisher $PUBLISHER 2>/dev/null
-tfx extension publisher create -t $ADO_ARTIFACTORY_API_KEY --publisher $PUBLISHER --display-name $PUBLISHER --description "Publishes Artifactory extension privately for sanity tests"
+tfx extension unpublish -t $ADO_ARTIFACTORY_API_KEY --extension-id jfrog-artifactory-vsts-extension --publisher $PUBLISHER
 tfx extension create --manifest-globs vss-extension-private.json --publisher $PUBLISHER
 tfx extension publish -t $ADO_ARTIFACTORY_API_KEY --publisher $PUBLISHER --manifests vss-extension-private.json --override "{\"public\": false}" --share-with $ADO_ARTIFACTORY_DEVELOPER
 tfx extension install --publisher $PUBLISHER --extension-id jfrog-artifactory-vsts-extension --service-url https://$ADO_ARTIFACTORY_DEVELOPER.visualstudio.com -t $ADO_ARTIFACTORY_API_KEY

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "Apache-2.0",
     "dependencies": {
-        "tfx-cli": "0.6.4"
+        "tfx-cli": "0.9.2"
     },
     "devDependencies": {
         "@types/mocha": "^8.0.4",


### PR DESCRIPTION
Due to the removal of the publisher REST API, the script began to produce the following error:
`error: Error: Failed Request: Bad Request(400) - Creating a publisher from command line is not supported. You can create a publisher directly in the Visual Studio Marketplace: https://aka.ms/vsm-create-publisher`

Creating a publisher manually will be a precondition going forward. The command was also [removed](https://github.com/microsoft/tfs-cli/releases/tag/0.9.0) from `tfx-cli` on newer versions.