### PR TITLE
Reduce extension size to 22M

### DIFF
--- a/buildScripts/build.js
+++ b/buildScripts/build.js
@@ -17,7 +17,7 @@ installTests();
 function installArtifactoryTaskUtils() {
     clean(TASKS_UTILS_DIR, true);
     execNpm('i', TASKS_UTILS_DIR);
-    exec('npx clean-modules -y --exclude "**/shelljs/src/test.js" ' + path.join(TASKS_UTILS_DIR, 'node_modules'), { stdio: [0, 1, 2] });
+    exec('npx clean-modules -y --exclude "**/shelljs/src/test.js" --directory ' + path.join(TASKS_UTILS_DIR, 'node_modules'), { stdio: [0, 1, 2] });
     execNpm('pack', TASKS_UTILS_DIR);
 }
 

--- a/tasks/Distribution/package.json
+++ b/tasks/Distribution/package.json
@@ -10,7 +10,6 @@
         "compile": "npx tsc -p ./"
     },
     "dependencies": {
-        "@types/q": "^1.5.4",
         "artifactory-tasks-utils": "file:../../artifactory-tasks-utils/artifactory-tasks-utils-1.0.0.tgz"
     }
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-azure-devops-extension#testing) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

Resolves #268 

* clean-modules@2.0 introduced a breaking change of path to `node_modules` should now be supplied to the --directory option. Since we are using `"clean-modules": "^1.0.4"`, we got this update without notice. This PR fixes this issue by adding the missing `--directory` flag.
* Remove the redundant `@types/q` dependency from the Distribution task. 

Results:
Before: 31M
After: 22M or 23392650 Bytes